### PR TITLE
Add file type filter and display match reason in search

### DIFF
--- a/src/app/dashboard/siadil/components/ui/FilterPopover.tsx
+++ b/src/app/dashboard/siadil/components/ui/FilterPopover.tsx
@@ -129,6 +129,23 @@ export const FilterPopover = forwardRef<HTMLDivElement, FilterPopoverProps>(
               </div>
             )}
           </div>
+          {/* TAMBAHKAN FILTER TIPE FILE DI SINI */}
+          <div>
+            <label
+              htmlFor="fileType"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              File Type (e.g., pdf, docx)
+            </label>
+            <input
+              type="text"
+              name="fileType"
+              id="fileType"
+              value={filters.fileType || ""}
+              onChange={onFilterChange}
+              className="w-full text-sm text-gray-900 border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300"
+              placeholder="pdf"
+            />
+          </div>
         </div>
 
         <div className="p-4 border-t border-gray-200 dark:border-gray-600 flex justify-end space-x-2 bg-gray-50 dark:bg-gray-800/50">

--- a/src/app/dashboard/siadil/hooks/useDocumentFilters.ts
+++ b/src/app/dashboard/siadil/hooks/useDocumentFilters.ts
@@ -9,6 +9,7 @@ const initialFilters: Filters = {
   expireDateStart: "",
   expireDateEnd: "",
   expireIn: {},
+  fileType: "",
 };
 
 export const useDocumentFilters = (
@@ -85,24 +86,29 @@ export const useDocumentFilters = (
         doc.number.toLowerCase().includes(filters.keyword.toLowerCase()) ||
         doc.title.toLowerCase().includes(filters.keyword.toLowerCase());
 
-      // ▼▼▼ INI BAGIAN LOGIKA PENTINGNYA ▼▼▼
       const archiveMatch =
         filters.archive.length === 0 || filters.archive.includes(doc.archive);
-      // ▲▲▲ INI BAGIAN LOGIKA PENTINGNYA ▲▲▲
 
       const docDateStartMatch =
         filters.docDateStart === "" || doc.documentDate >= filters.docDateStart;
       const docDateEndMatch =
         filters.docDateEnd === "" || doc.documentDate <= filters.docDateEnd;
 
+      const fileTypeMatch =
+        !filters.fileType ||
+        (doc.fileType &&
+          doc.fileType.toLowerCase().includes(filters.fileType.toLowerCase()));
+
       let finalExpireMatch = true;
       if (expireFilterMethod === "range") {
         const expireDateStartMatch =
           filters.expireDateStart === "" ||
-          doc.expireDate >= filters.expireDateStart;
+          !!(doc.expireDate && doc.expireDate >= filters.expireDateStart);
+
         const expireDateEndMatch =
           filters.expireDateEnd === "" ||
-          doc.expireDate <= filters.expireDateEnd;
+          !!(doc.expireDate && doc.expireDate <= filters.expireDateEnd);
+
         finalExpireMatch = expireDateStartMatch && expireDateEndMatch;
       } else {
         const activeExpireInPeriods = Object.keys(filters.expireIn);
@@ -130,6 +136,7 @@ export const useDocumentFilters = (
         archiveMatch &&
         docDateStartMatch &&
         docDateEndMatch &&
+        fileTypeMatch &&
         finalExpireMatch
       );
     });

--- a/src/app/dashboard/siadil/page.tsx
+++ b/src/app/dashboard/siadil/page.tsx
@@ -278,10 +278,14 @@ export default function SiadilPage() {
         return (maxId + 1).toString();
       };
 
+      const fileName = newDocument.file.name;
+      const fileExtension = fileName.split(".").pop()?.toLowerCase();
+
       const newDoc: Document = {
         id: getNextId(),
         parentId: currentFolderId,
         title: newDocument.title || newDocument.file.name,
+        fileType: fileExtension,
 
         number: newDocument.number,
         description: newDocument.description,

--- a/src/app/dashboard/siadil/types.ts
+++ b/src/app/dashboard/siadil/types.ts
@@ -20,6 +20,7 @@ export type Document = {
   createdDate: string;
   updatedDate: string;
   parentId: string;
+  fileType?: string;
   isStarred?: boolean;
   lastAccessed?: string;
   content?: string;
@@ -32,6 +33,7 @@ export type Filters = {
   expireDateStart: string;
   expireDateEnd: string;
   expireIn: Record<string, boolean>;
+  fileType: string;
 };
 
 export type NewDocumentData = {


### PR DESCRIPTION
Introduces a file type filter to the document filtering logic and UI, allowing users to filter documents by file extension. The search popup now displays the reason for each match, improving search result clarity. Document type information is now stored and set on upload.